### PR TITLE
fix: missing imports if not present in first package file

### DIFF
--- a/cmd/testdata/import_packages/no_imports.go
+++ b/cmd/testdata/import_packages/no_imports.go
@@ -1,0 +1,1 @@
+package test


### PR DESCRIPTION
When generating getters and setters, if they reference strucs imported in a file other than the first in the package, the import is missing, e.g.:

```go
package common

//go:generate go tool accessory -type Log -receiver log -output log_gen.go
type Log struct {
	createdAt time.Time    `accessor:"getter"`
}
```
generates: 
```
package common

func (log *Log) CreatedAt() Time {
	if log == nil {
		return Time{}
	}
	return log.createdAt
}
```
expected:
```go
package common

import (
	"time"
)

func (log *Log) CreatedAt() time.Time {
	if log == nil {
		return time.Time{}
	}
	return log.createdAt
}
```